### PR TITLE
feat: get dependabot to use feat prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,8 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+   commit_message:
+      prefix: "feat"
+      prefix_development: "build"
+      include_scope: true
   open-pull-requests-limit: 10


### PR DESCRIPTION

When change logs are created, dependency updates will now be persisted into the changelog