### PR TITLE
build: use the correct dependabot config version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,8 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  commit_message:
+  commit-message:
     prefix: "feat"
-    prefix_development: "build"
-    include_scope: true
+    prefix-development: "build"
+    include: "scope"
   open-pull-requests-limit: 10


### PR DESCRIPTION


old: `commit_message`
new: `commit-message`

https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#commit-message