### PR TITLE
feat(eslint/rule): adding eqeqeq rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
     sourceType: 'module',
   },
   rules: {
+    eqeqeq: ['error', 'always', { null: 'ignore' }],
     '@typescript-eslint/no-unused-vars': 'error',
     '@typescript-eslint/explicit-function-return-type': 'error',
   },


### PR DESCRIPTION
This forces `===` to be used over `==` unless using `== null`

https://eslint.org/docs/rules/eqeqeq

BREAKING CHANGE: this modifies the default rules exported