### PR TITLE
feat(eslint/rule): add no-var rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
     sourceType: 'module',
   },
   rules: {
+    'no-var': 'error',
     '@typescript-eslint/no-unused-vars': 'error',
     '@typescript-eslint/explicit-function-return-type': 'error',
   },


### PR DESCRIPTION
This forces everyone to use const/let

https://eslint.org/docs/rules/no-var

BREAKING CHANGE: this is a breaking rule change