### PR TITLE
build: group typescript eslint/pretiter dep upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+
 updates:
 - package-ecosystem: "github-actions"
   directory: "/"
@@ -13,3 +14,11 @@ updates:
     prefix-development: "build"
     include: "scope"
   open-pull-requests-limit: 10
+  groups:
+    "typescript-eslint-prettier":
+      patterns:
+        - "typescript"
+        - "eslint"
+        - "eslint-plugin-*"
+        - "prettier"
+        - "@typescript-eslint/*"


### PR DESCRIPTION
#### Motivation

It would be nice to merge just one pull request not multiple when updating the core plugins, they also sometimes do not work unless they are all merged together.

#### Modification

Adds a group for the core typescript, eslint, prettier and their plugins.