### PR TITLE
feat: add @typescript-eslint/recommended-type-checked

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -39,9 +39,16 @@ module.exports = {
       parser: '@typescript-eslint/parser',
     },
     {
+      parserOptions: {
+        project: true,
+      },
       /** Overrides for typescript */
       files: ['**/*.ts', '**/*.tsx'],
-      extends: ['plugin:@typescript-eslint/recommended', 'plugin:prettier/recommended'],
+      extends: [
+        'plugin:@typescript-eslint/recommended',
+        'plugin:@typescript-eslint/recommended-type-checked',
+        'plugin:prettier/recommended',
+      ],
       rules: {
         '@typescript-eslint/no-unused-vars': 'error',
         '@typescript-eslint/explicit-function-return-type': 'error',

--- a/src/__test__/class.test.ts
+++ b/src/__test__/class.test.ts
@@ -4,7 +4,7 @@ export class FooBar {
   }
 
   async bar(): Promise<string> {
-    return 'bar';
+    return await Promise.resolve('bar');
   }
 
   // Should allow `!` in tests

--- a/src/__test__/class.ts
+++ b/src/__test__/class.ts
@@ -4,7 +4,7 @@ export class FooBar {
   }
 
   async bar(): Promise<string> {
-    return 'bar';
+    return await Promise.resolve('bar');
   }
 
   /**


### PR DESCRIPTION
#### Motivation

Adds more complex type checking including rules like requiring await for promises and async functions.

full list of rules can be found https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/recommended-type-checked.ts


#### Modification

adds typescript-eslints recommended type checking rules

an additional `project: true` was needed so that eslint can use the type checker from typescript