### PR TITLE
feat: Disallow comma operators

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,6 +22,9 @@ module.exports = {
     // Default simple-import-sort rules
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',
+
+    // Disallow comma operators
+    'no-sequences': 'error',
   },
 
   overrides: [


### PR DESCRIPTION
This is often an accident, such as in

```typescript
assert.throws(() => {
  func(), Error;
});
```

That code should instead be:

```typescript
assert.throws(() => {
  func();
}, Error);
```